### PR TITLE
Feature/render layers

### DIFF
--- a/resources/data/definitions.json
+++ b/resources/data/definitions.json
@@ -1,94 +1,118 @@
 {
-  "num_comp_def": 20,
-  "systems":[
-    {"name": "Animations",
-      "components": ["Animation", "Position"],
-      "functions": [
-        {"step": "UPDATE_FIXED",  "fn": "AnimSystem"},
-        {"step": "UPDATE_DRAW",   "fn": "AnimRender"},
-        {"step": "GAME_READY",    "fn": "AnimLoad"}
-      ]
-    },
-    {"name": "Sprites",
-      "components": ["Sprite", "Position"],
-      "functions": [
-        {"step": "UPDATE_DRAW",   "fn": "SpriteRender"},
-        {"step": "GAME_READY",    "fn": "SpriteLoad"}
-      ]
-    },
-    {"name": "Controller",
-      "components": ["Input", "Position"],
-      "functions": [
-        {"step": "UPDATE_FRAME",  "fn": "InputSystem"},
-        {"step": "GAME_READY",    "fn": "InputLoad"}
-      ]
-    },
-    {"name": "Positions",
-      "components": ["Position"],
-      "functions": [
-        {"step": "GAME_READY",    "fn": "PositionLoad"}
-      ]
-    },
-    {"name": "Physics",
-      "components": ["RigidBody", "Position"],
-      "functions": [
-        {"step": "UPDATE_POST",   "fn": "PhysicsSystem"},
-        {"step": "UPDATE_PRE" ,   "fn": "PhysicsCollision"},
-        {"step": "GAME_READY",    "fn": "PhysicsLoad"}
-      ],
-      "init": "PhysicsInit"
-    },
-    {"name": "Forces",
-      "components": ["Force"],
-      "functions": [
-        {"step": "UPDATE_FIXED",  "fn": "ForceSystem"},
-        {"step": "UPDATE_FINAL",  "fn": "ForceCleanup"},
-        {"step": "GAME_READY",    "fn": "ForceLoad"}
-      ]
-    },
-    {"name": "Levels",
-      "components": ["Level"],
-      "functions": [
-        {"step": "UPDATE_DRAW",   "fn": "LevelRender"},
-        {"step": "GAME_LOADING",  "fn": "LevelLoad"},
-        {"step": "GAME_READY",    "fn": "LevelReady"}
-      ]
-    },
-    {"name": "Render",
-      "components": ["Camera"],
-      "functions": [
-        {"step": "UPDATE_DRAW_BEGIN","fn": "RenderBegin"},
-        {"step": "UPDATE_DRAW_END",  "fn": "RenderEnd"},
-        {"step": "GAME_READY",       "fn": "RenderLoad"}
-      ]
-    },
-    {"name": "Cameras",
-      "components": ["Camera", "Tracking"],
-      "functions": [
-        {"step": "UPDATE_POST",   "fn": "CameraSystem"},
-        {"step": "GAME_LOADING",  "fn": "CameraLoad"},
-        {"step": "GAME_READY",    "fn": "CameraReady"}
-      ]
-    },
-     {"name": "Expiration",
-      "components": ["Expiry"],
-      "functions": [
-        {"step": "UPDATE_FINAL",  "fn": "ExpirationSystem"}
-      ]
-    }
-  ],
+  "num_comp_def": 22,
   "components": [
-    "Sprite", "Animation", "Position", "Input", "RigidBody", "Force", "Camera"
+    "Sprite", "Animation", "View", "Position", "Input", "Camera"
   ],
+  "systems": ["Animations", "Sprites", "Cameras", "Render"],
+  "Animations":{
+    "components": ["Animation", "Sprite"],
+    "syncs": [
+      {"step": "UPDATE_FIXED",  "fn": "AnimSystem"}
+    ],
+    "states": [
+      {"step": "GAME_READY",    "fn": "AnimLoad"}
+    ]
+  },
+  "Sprites" : {
+    "components": ["Sprite", "Position"],
+    "init": "SpritesInit"
+  },
+  "Controller": {
+    "components": ["Input", "Position"],
+    "syncs": [
+      {"step": "UPDATE_FRAME",  "fn": "InputSystem"}
+    ],
+    "states":[
+      {"step": "GAME_READY",    "fn": "InputLoad"}
+    ]
+  },
+  "Positions": {
+    "components": ["Position"],
+    "states": [
+      {"step": "GAME_READY",    "fn": "PositionLoad"}
+    ]
+  },
+  "Physics": {
+    "components": ["RigidBody", "Position"],
+    "syncs": [
+      {"step": "UPDATE_POST",   "fn": "PhysicsSystem"},
+      {"step": "UPDATE_PRE" ,   "fn": "PhysicsCollision"}
+    ],
+    "states": [
+      {"step": "GAME_READY",    "fn": "PhysicsLoad"}
+    ],
+    "init": "PhysicsInit"
+  },
+  "Forces": {
+    "components": ["Force"],
+    "syncs": [
+      {"step": "UPDATE_FIXED",  "fn": "ForceSystem"},
+      {"step": "UPDATE_FINAL",  "fn": "ForceCleanup"}
+    ],
+    "states": [
+      {"step": "GAME_READY",    "fn": "ForceLoad"}
+    ]
+  },
+  "Levels": {
+    "components": ["Level"],
+    "states": [
+      {"step": "GAME_LOADING",  "fn": "LevelLoad"},
+      {"step": "GAME_READY",    "fn": "LevelReady"}
+    ]
+  },
+  "Render": {
+    "components": ["View"],
+    "syncs": [
+      {"step": "UPDATE_DRAW_BEGIN","fn": "RenderBegin"},
+      {"step": "UPDATE_DRAW_END",  "fn": "RenderEnd"},
+      {"step": "UPDATE_DRAW",      "fn": "RenderDraw"}
+    ],
+    "states": [
+      {"step": "GAME_READY",       "fn": "RenderLoad"}
+    ]
+  },
+  "Cameras": {
+    "components": ["Camera"],
+    "syncs": [
+      {"step": "UPDATE_POST",      "fn": "CameraSystem"},
+      {"step": "UPDATE_DRAW_BEGIN","fn": "CameraBegin"},
+      {"step": "UPDATE_DRAW_END",  "fn": "CameraEnd"}
+    ],
+    "states": [
+      {"step": "GAME_LOADING",     "fn": "CameraLoad"},
+      {"step": "GAME_READY",       "fn": "CameraReady"}
+    ]
+  },
+  "Expiration": {
+    "components": ["Expiry"],
+    "syncs": [
+      {"step": "UPDATE_FINAL",  "fn": "ExpirationSystem"}
+    ]
+  },
   "Sprite":{
     "func": "SpriteInit",
     "list": [
-      {"name": "tile_blank", "sheet_id": "SHEET_TILE", "sheet_index": 0},
-      {"name": "tile_tiwaz", "sheet_id": "SHEET_TILE", "sheet_index": 1},
-      {"name": "tile_algiz", "sheet_id": "SHEET_TILE", "sheet_index": 2},
-      {"name": "tile_raidho","sheet_id": "SHEET_TILE", "sheet_index": 3},
-      {"name": "tile_laguz", "sheet_id": "SHEET_TILE", "sheet_index": 4},
-      {"name": "tile_ingwaz","sheet_id": "SHEET_TILE", "sheet_index": 5}
+      {"name": "player", "layer": 1,
+        "sheet_id": "SHEET_CHAR", "sheet_index": 0
+      },
+      {"name": "tile_blank", "layer": 0, 
+        "sheet_id": "SHEET_TILE", "sheet_index": 0
+      },
+      {"name": "tile_tiwaz", "layer": 0,
+        "sheet_id": "SHEET_TILE", "sheet_index": 1
+      },
+      {"name": "tile_algiz", "layer": 0,
+        "sheet_id": "SHEET_TILE", "sheet_index": 2
+      },
+      {"name": "tile_raidho", "layer": 0,
+        "sheet_id": "SHEET_TILE", "sheet_index": 3
+      },
+      {"name": "tile_laguz", "layer": 0,
+        "sheet_id": "SHEET_TILE", "sheet_index": 4
+      },
+      {"name": "tile_ingwaz", "layer": 0,
+        "sheet_id": "SHEET_TILE", "sheet_index": 5
+      }
     ]
   },
   "Animation": {
@@ -149,16 +173,10 @@
     "list": [
       {
         "name": "main_cam",
-        "zoom":     2.0,
+        "zoom":     1.0,
         "rotation": 0,
         "offset_x": 100,
-        "offset_y": 150,
-        "width":    1600,
-        "height":   1200,
-        "bounds_x": 0,
-        "bounds_y": 0,
-        "bounds_w": 1600,
-        "bounds_h": 1200
+        "offset_y": 150
       }
     ]
   },
@@ -185,12 +203,33 @@
       }
     ]
   },
+  "View": {
+    "func": "ViewInit",
+    "list": [
+      {
+        "name":     "bg",
+        "layer":    0,
+        "bounds_x": 0,
+        "bounds_y": 0,
+        "bounds_w": 1600,
+        "bounds_h": 1200
+      },
+      {
+        "name":     "main",
+        "layer":    1,
+        "bounds_x": 0,
+        "bounds_y": 0,
+        "bounds_w": 1600,
+        "bounds_h": 1200
+      }
+    ]
+  },
   "Input": {
     "func": "InputInit",
     "list": [{"name": "player"}]
   },
   "prefabs": {
-    "count": 8,
+    "count": 10,
     "list":[
       {
         "name": "main_cam",
@@ -198,9 +237,15 @@
         "list": ["Position", "Camera"]
       },
       {
+        "name":     "views",
+        "count":    2,
+        "list":     ["View"],
+        "contains": ["bg","main"]
+      },
+      {
         "name": "player",
-        "count": 2,
-        "list": ["Animation", "Position"]
+        "count": 3,
+        "list": ["Sprite", "Animation", "Position"]
       },
       {
         "name": "tile",

--- a/resources/data/definitions.json
+++ b/resources/data/definitions.json
@@ -15,6 +15,9 @@
   },
   "Sprites" : {
     "components": ["Sprite", "Position"],
+    "states": [
+      {"step": "GAME_READY", "fn": "SpriteLoad"}
+    ],
     "init": "SpritesInit"
   },
   "Controller": {
@@ -92,7 +95,7 @@
   "Sprite":{
     "func": "SpriteInit",
     "list": [
-      {"name": "player", "layer": 1,
+      {"name": "player", "layer": 1, "scale": 2.5,
         "sheet_id": "SHEET_CHAR", "sheet_index": 0
       },
       {"name": "tile_blank", "layer": 0, 
@@ -118,7 +121,7 @@
   "Animation": {
     "func": "AnimInit",
     "list": [
-      {"name": "player", "sheet_id": "SHEET_PLAYER",
+      {"name": "player", "sheet_id": "SHEET_CHAR",
         "states": [
           {"state": "WALK", "loop": false, "end": "SUPSEND",
             "sequences": [
@@ -175,8 +178,10 @@
         "name": "main_cam",
         "zoom":     1.0,
         "rotation": 0,
-        "offset_x": 100,
-        "offset_y": 150
+        "offset_x": 320,
+        "offset_y": 120,
+        "target_x": 160,
+        "target_y": 60
       }
     ]
   },
@@ -186,8 +191,8 @@
     "list": [
       {
         "name": "main_cam",
-        "posx": 800,
-        "posy": 600
+        "posx": 400,
+        "posy": 300
       },
       {
         "name": "player",
@@ -211,16 +216,20 @@
         "layer":    0,
         "bounds_x": 0,
         "bounds_y": 0,
-        "bounds_w": 1600,
-        "bounds_h": 1200
+        "bounds_w": 1920,
+        "bounds_h": 1080,
+        "offset_x": -680,
+        "offset_y": -420
       },
       {
         "name":     "main",
         "layer":    1,
         "bounds_x": 0,
         "bounds_y": 0,
-        "bounds_w": 1600,
-        "bounds_h": 1200
+        "bounds_w": 1920,
+        "bounds_h": 1080,
+        "offset_x": -680,
+        "offset_y": -420
       }
     ]
   },

--- a/resources/data/scenes/scene_01.json
+++ b/resources/data/scenes/scene_01.json
@@ -63,7 +63,7 @@
     {"name": "main_cam", "pos_x": 0, "pos_y": 0},
     {"name": "bg", "pos_x": 0, "pos_y": 0},
     {"name": "main", "pos_x": 0, "pos_y": 0},
-    {"name": "player",   "pos_x": 800, "pos_y": 600}
+    {"name": "player",   "pos_x": 400, "pos_y": 200}
   ],  
   "metadata": {
     "points": 10

--- a/resources/data/scenes/scene_01.json
+++ b/resources/data/scenes/scene_01.json
@@ -61,6 +61,8 @@
   ],
   "entities": [
     {"name": "main_cam", "pos_x": 0, "pos_y": 0},
+    {"name": "bg", "pos_x": 0, "pos_y": 0},
+    {"name": "main", "pos_x": 0, "pos_y": 0},
     {"name": "player",   "pos_x": 800, "pos_y": 600}
   ],  
   "metadata": {

--- a/src/component_define.h
+++ b/src/component_define.h
@@ -10,6 +10,7 @@
 
 bool InputInit(void* comp, component_entry_t* data);
 bool SpriteInit(void* comp, component_entry_t* data);
+bool ViewInit(void* comp, component_entry_t* data);
 bool ForceInit(void* comp, component_entry_t* data);
 bool RigidBodyInit(void* comp, component_entry_t* data);
 bool AnimInit(void* comp, component_entry_t* data);
@@ -22,6 +23,7 @@ bool ParseRigidBodyComponent(cJSON* j, rigid_body_t* out);
 bool ParseForceComponent(cJSON* j, force_t* out);
 bool ParsePositionComponent(cJSON* j, position_t* out);
 bool ParseInputComponent(cJSON* j, input_t* out);
+bool ParseCameraComponent(cJSON* j, camera_t* out);
 
 typedef struct{
   anim_player_t   player;
@@ -45,10 +47,10 @@ typedef struct{
 }level_t;
 
 typedef struct{
-  viewport_t  view;
-  Camera2D    camera;
-}cam_comp_t;
-bool ParseCameraComponent(cJSON* j, cam_comp_t* out);
+  viewport_t    view;
+  RenderLayer   layer;
+}view_comp_t;
+bool ParseViewComponent(cJSON* j, view_comp_t* out);
 
 typedef struct{
   camera_ctx_t      ctx;

--- a/src/components.h
+++ b/src/components.h
@@ -3,7 +3,7 @@
 #include "game_tools.h"
 #include "game_common.h"
 
-#define NUM_COMP_CORE   15
+#define NUM_COMP_CORE   14
 #define MAX             1024
 #define MAX_COMPONENTS  512
 #define MAX_PLAYERS     2
@@ -12,6 +12,7 @@
 #define PHYS_ID      ComponentGetID("RigidBody")
 #define ANIM_ID      ComponentGetID("Animation")
 #define SPR_ID       ComponentGetID("Sprite")
+#define VIEW_ID      ComponentGetID("View")
 #define INPUT_ID     ComponentGetID("Input")
 #define CAM_ID       ComponentGetID("Camera")
 #define TRACK_ID     ComponentGetID("Track")

--- a/src/game.c
+++ b/src/game.c
@@ -26,19 +26,23 @@ void PreUpdate(void){
 void FixedUpdate(void){
   GP.game_frames++;
   GameEvent(GameEvent_ToNotif(GAME_EVENT_STEP), &world , UPDATE_FIXED);
+  GameEvent(GameEvent_ToNotif(GAME_EVENT_SYNC), &world , UPDATE_FIXED);
 }
 
 void PostUpdate(void){
   GameEvent(GameEvent_ToNotif(GAME_EVENT_STEP), &world , UPDATE_POST);
+  GameEvent(GameEvent_ToNotif(GAME_EVENT_SYNC), &world , UPDATE_POST);
 } 
 
 void FinalUpdate(void){
   GameEvent(GameEvent_ToNotif(GAME_EVENT_STEP), &world , UPDATE_FINAL);
+  GameEvent(GameEvent_ToNotif(GAME_EVENT_SYNC), &world , UPDATE_FINAL);
 }
 
 // Gameplay Screen Update logic
 void UpdateGameplayScreen(void){
   GameEvent(GameEvent_ToNotif(GAME_EVENT_STEP), &world , UPDATE_FRAME);
+  GameEvent(GameEvent_ToNotif(GAME_EVENT_SYNC), &world , UPDATE_FRAME);
 
 }
 
@@ -46,10 +50,17 @@ void UpdateGameplayScreen(void){
 void BeginDraw(void){
 
   GameEvent(GameEvent_ToNotif(GAME_EVENT_STEP), &world , UPDATE_DRAW_BEGIN);
+  GameEvent(GameEvent_ToNotif(GAME_EVENT_SYNC), &world , UPDATE_DRAW_BEGIN);
 }
 
+void DrawGameplayScreen(void){
+
+  GameEvent(GameEvent_ToNotif(GAME_EVENT_STEP), &world , UPDATE_DRAW);
+  GameEvent(GameEvent_ToNotif(GAME_EVENT_SYNC), &world , UPDATE_DRAW);
+}
 void EndDraw(void){
   GameEvent(GameEvent_ToNotif(GAME_EVENT_STEP), &world , UPDATE_DRAW_END);
+  GameEvent(GameEvent_ToNotif(GAME_EVENT_SYNC), &world , UPDATE_DRAW_END);
 
 }
 

--- a/src/game_assets.h
+++ b/src/game_assets.h
@@ -45,8 +45,10 @@ void InitResources();
 typedef enum{
   LAYER_ROOT = -1,
   LAYER_BG,
+  LAYER_FLOOR,
   LAYER_MAIN,
   LAYER_TOP,
+  LAYER_UI,
   LAYER_DONE
 }RenderLayer;
 
@@ -148,13 +150,13 @@ bool AnimPlayerState(anim_player_t*, anim_t*, AnimState s);
 //SPRITE_T===>
 struct sprite_s{
   int         sheet_id, index;
-  float       rot;
+  float       rot, scale;
   Vector2     offset;
   RenderLayer layer;
   collision_d coll;
 };
 sprite_t* InitSprite(SheetID, int);
-
+void DrawSprite(sprite_t* spr, Vector2 position);
 sprite_slice_t* InitSliceFromData(sprite_d*);
 void DrawSlice(sprite_slice_t*, Vector2 position,float rot);
 #endif

--- a/src/game_camera.c
+++ b/src/game_camera.c
@@ -51,7 +51,13 @@ void TrackingFollow(camera_t* cam, track_mode_d t, Vector2 v){
 }
 
 bool CameraInit(void* comp, component_entry_t* json){
-  cam_comp_t* cc = comp;
+  camera_t* cc = comp;
 
   return ParseCameraComponent(json->data, cc);
+}
+
+bool ViewInit(void* comp, component_entry_t* json){
+  view_comp_t* vc = comp;
+
+  return ParseViewComponent(json->data, vc);
 }

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -7,13 +7,14 @@ const component_define_t CORE_COMPONENTS[NUM_COMP_CORE] = {
   {"RigidBody", sizeof(rigid_body_t)},
   {"Animation", sizeof(anim_comp_t)},
   {"Sprite",    sizeof(sprite_t)},
+  {"View",      sizeof(view_comp_t)},
   {"Input",     sizeof(input_t)},
-  {"Camera",    sizeof(cam_comp_t)},
+  {"Camera",    sizeof(camera_t)},
   {"Track",     sizeof(track_comp_t)},
   {"Type",      sizeof(EntityType)},
-  {"Stat",      sizeof(stat_t)},
+  //{"Stat",      sizeof(stat_t)},
   {"Force",     sizeof(force_t)},
-  {"Name",      0}, //TODO
+  //{"Name",      0}, //TODO
   {"State",     sizeof(state_comp_t)},
   {"Follow",    sizeof(follow_comp_t)},
   {"Level",     sizeof(level_t)},
@@ -23,6 +24,7 @@ const component_define_t CORE_COMPONENTS[NUM_COMP_CORE] = {
 const component_func_t COMPFUNC_LOOKUP[NUM_COMP_CORE] = {
   {"Animation",   AnimInit},
   {"Sprite",      SpriteInit},
+  {"View",        ViewInit},
   {"Anim",        AnimInit},
   {"RigidBody",   RigidBodyInit},
   {"Force",       ForceInit},
@@ -54,8 +56,10 @@ void GameInitPrefabs(world_t* w, game_t* g){
     for(int j = 0; j < def.num_comp; j++){
       comp_id_t cid = ComponentGetID(def.components[j]);
 
-      if(cid == INVALID_COMPONENT)
+      if(cid == INVALID_COMPONENT){
+        TraceLog(LOG_WARNING, "=== INIT PREFABS ===\n unable to find compnent %s", def.components[j]);
         continue;
+      }
 
       ComponentInitFn fn = ComponentFuncLookup(def.components[j]);
      
@@ -71,7 +75,9 @@ void GameInitPrefabs(world_t* w, game_t* g){
         continue;
       }
         
-      fn(ComponentAdd(w, prefab, cid), data);
+      if(!fn(ComponentAdd(w, prefab, cid), data))
+        TraceLog(LOG_WARNING, "=== INIT PREFABS ===\n Failed to add component %s to Entity %s", def.components[j], def.name);
+
     }
   }
 }

--- a/src/game_define.h
+++ b/src/game_define.h
@@ -74,7 +74,8 @@ extern const component_func_t COMPFUNC_LOOKUP[NUM_COMP_CORE];
 typedef struct{
   char*       name;
   SystemFn    init;
-  SystemCB    steps[UPDATE_DONE];
+  SystemFn    steps[UPDATE_DONE];
+  SystemCB    syncs[UPDATE_DONE];
   SystemCB    states[GAME_DONE];
   int         num_req;
   const char* components[NUM_REL];

--- a/src/game_enum.h
+++ b/src/game_enum.h
@@ -8,7 +8,8 @@
 #define EVENT_PHYS_BASE   0x3000
 #define EVENT_POS_BASE    0x4000
 #define EVENT_ANIM_BASE   0x5000
-#define EVENT_COMBAT_BASE 0x6000
+#define EVENT_VIEW_BASE   0x6000
+#define EVENT_COMBAT_BASE 0x7000
 #define EVENT_BASE_MASK   0xFFFFF000
 #define EVENT_ID_MASK     0x00000FFF
 
@@ -28,6 +29,7 @@ static inline uint32_t EVENT_ID(uint64_t n) {
 }
 typedef enum{
   GAME_EVENT_STATE,
+  GAME_EVENT_SYNC,
   GAME_EVENT_STEP,
   GAME_EVENT_COUNT
 }GameEventID;

--- a/src/game_events.c
+++ b/src/game_events.c
@@ -364,7 +364,6 @@ notification_t* RegisterNotification(notification_pool_t* p, char* name){
   strcpy(notif->name, name);
   HashPut(&p->map, n, notif);
   p->count++;
-  TraceLog(LOG_INFO, "==== REGISTER NOTIFICATION\n %s %d", name, n);
   return notif; 
 }
 

--- a/src/game_math.h
+++ b/src/game_math.h
@@ -188,21 +188,17 @@ static inline Vector2 math_normal_rec(Rectangle collider, Rectangle target, Rect
   Vector2 result = Vector2Zero();
   if (overlap.width < overlap.height - threshold) {
     if (col_pos.x > tar_pos.x){
-//      TraceLog(LOG_INFO,"Hit from the left side of target\n");
       result.x = -1;
     }
     else{
-  //    TraceLog(LOG_INFO,"Hit from the right side of target\n");
       result.x = 1;
     }
   }
   else if (overlap.height < overlap.width - threshold) {
     if (col_pos.y > tar_pos.y){
-    //  TraceLog(LOG_INFO,"Hit from the top side of target\n");
       result.y = -1;
     }
     else{
-      //TraceLog(LOG_INFO,"Hit from the bottom side of target\n");
       result.y = 1;
     }
   }

--- a/src/game_parse.c
+++ b/src/game_parse.c
@@ -64,6 +64,7 @@ bool ParseSpriteComponent(cJSON* j, sprite_t* out){
   int sheet_id = StringToSheetID(sheet);
   out->index = Json_GetInt(j, "sheet_index", -1);
   out->layer = Json_GetInt(j, "layer", -1);
+  out->scale = Json_GetFloat(j, "scale", 1);
   out->sheet_id = sheet_id;
 
   return sheet_id > -1;
@@ -119,6 +120,7 @@ bool ParseAnimComponent(cJSON* j, anim_comp_t* out){
     }  
   }
 
+  return sheet_id > -1;
 }
 
 bool ParsePositionComponent(cJSON* j, position_t* out){
@@ -146,10 +148,12 @@ bool ParseCameraComponent(cJSON* j, camera_t* out){
   float offx = Json_GetFloat(j, "offset_x", 0.f);
   float offy = Json_GetFloat(j, "offset_y", 0.f);
 
-  Vector2 offset = VEC_NEW(offx, offy);
+  float tarx = Json_GetFloat(j, "target_x", 0.f);
+  float tary = Json_GetFloat(j, "target_y", 0.f);
 
-  out->offset = offset;
-  out->target = offset;
+  out->offset = VEC_NEW(offx, offy);
+  out->target = VEC_NEW(tarx, tary);
+
   return true;
 }
 bool ParseViewComponent(cJSON* j, view_comp_t* out){
@@ -166,6 +170,8 @@ bool ParseViewComponent(cJSON* j, view_comp_t* out){
 
   out->view = *InitView(size, bounds, 0);
   out->layer = Json_GetInt(j, "layer", -1);
+  out->view.origin.x = Json_GetFloat(j, "offset_x", 0);
+  out->view.origin.y = Json_GetFloat(j, "offset_y", 0);
   return true;
 }
 
@@ -406,8 +412,8 @@ bool ParseScene(cJSON* root, Scene* scene){
       e->prefab = GameCalloc("ParseScene", MAX_NAME_LEN, sizeof(char));
 
       Json_GetString(item, "name", e->prefab);
-      e->x = Json_GetFloat(item, "x", 0.0f);
-      e->y = Json_GetFloat(item, "y", 0.0f);
+      e->x = Json_GetFloat(item, "pos_x", 0.0f);
+      e->y = Json_GetFloat(item, "pos_y", 0.0f);
       e->type = Json_GetInt(item, "type", 0);
     }
   }

--- a/src/game_parse.c
+++ b/src/game_parse.c
@@ -62,10 +62,11 @@ bool ParseSpriteComponent(cJSON* j, sprite_t* out){
   char sheet[MAX_NAME_LEN];
   Json_GetString(j, "sheet_id", sheet);
   int sheet_id = StringToSheetID(sheet);
-  int idx = Json_GetInt(j, "sheet_index", -1);
-
+  out->index = Json_GetInt(j, "sheet_index", -1);
+  out->layer = Json_GetInt(j, "layer", -1);
   out->sheet_id = sheet_id;
-  out->index = idx;
+
+  return sheet_id > -1;
 }
 
 bool ParseInputComponent(cJSON* j, input_t* out){
@@ -135,30 +136,36 @@ bool ParsePositionComponent(cJSON* j, position_t* out){
   return true;
 }
 
-bool ParseCameraComponent(cJSON* j, cam_comp_t* out){
+bool ParseCameraComponent(cJSON* j, camera_t* out){
   if(!j)
     return false;
 
-  float zoom = Json_GetFloat(j, "zoom", 1.f);
-  float rot = Json_GetFloat(j, "rotation", 0.f);
+  out->zoom = Json_GetFloat(j, "zoom", 1.f);
+  out->rotation = Json_GetFloat(j, "rotation", 0.f);
 
   float offx = Json_GetFloat(j, "offset_x", 0.f);
   float offy = Json_GetFloat(j, "offset_y", 0.f);
 
   Vector2 offset = VEC_NEW(offx, offy);
 
-  out->camera = *InitCamera(zoom, rot, offset);
+  out->offset = offset;
+  out->target = offset;
+  return true;
+}
+bool ParseViewComponent(cJSON* j, view_comp_t* out){
+  if(!j)
+    return false;
 
   float bx = Json_GetFloat(j, "bounds_x", 0.f);
   float by = Json_GetFloat(j, "bounds_y", 0.f);
   float bw = Json_GetFloat(j, "bounds_w", 0.f);
   float bh = Json_GetFloat(j, "bounds_h", 0.f);
- 
+
   Rectangle bounds = RECT(bx, by, bw, bh);
   Vector2 size = VEC_NEW(bw, bh); 
 
   out->view = *InitView(size, bounds, 0);
-
+  out->layer = Json_GetInt(j, "layer", -1);
   return true;
 }
 
@@ -420,12 +427,7 @@ bool ParseSystems(cJSON* root, game_t* out)
 {
   if (!root || !out) return false;
 
-  cJSON* systems_json = cJSON_GetObjectItem(root, "systems");
-  if (!cJSON_IsArray(systems_json))
-  {
-    printf("ERROR: 'systems' array not found or invalid.\n");
-    return false;
-  }
+  cJSON* systems_json = cJSON_GetObjectItem(root,"systems");
 
   out->num_sys = cJSON_GetArraySize(systems_json);
   if (out->num_sys > NUM_SYS)
@@ -435,16 +437,17 @@ bool ParseSystems(cJSON* root, game_t* out)
   }
 
   int sys_idx = 0;
-  cJSON* sys_item;
-  cJSON_ArrayForEach(sys_item, systems_json)
+  cJSON* sys_name;
+  cJSON_ArrayForEach(sys_name, systems_json)
   {
+    cJSON* sys_item = cJSON_GetObjectItem(root, sys_name->valuestring);
     if (sys_idx >= NUM_SYS) break;
 
     system_define_t* sys = &out->systems[sys_idx++];
 
     // --- Name ---
     sys->name = GameCalloc("ParseSystems", MAX_NAME_LEN, sizeof(char));
-    Json_GetString(sys_item, "name", sys->name);
+    strcpy(sys->name, sys_name->valuestring);
 
     // --- Components ---
     cJSON* comps_json = cJSON_GetObjectItem(sys_item, "components");
@@ -464,16 +467,17 @@ bool ParseSystems(cJSON* root, game_t* out)
     }
 
     // --- Init function (optional) ---
+    
     cJSON* init_json = cJSON_GetObjectItem(sys_item, "init");
-    if (cJSON_IsString(init_json))
+    if(init_json){
       sys->init = SystemFunctionLookup(init_json->valuestring);
-
+    }
     // --- Functions array ---
-    cJSON* funcs_json = cJSON_GetObjectItem(sys_item, "functions");
-    if (cJSON_IsArray(funcs_json))
+    cJSON* sync_json = cJSON_GetObjectItem(sys_item, "syncs");
+    if (cJSON_IsArray(sync_json))
     {
       cJSON* f;
-      cJSON_ArrayForEach(f, funcs_json)
+      cJSON_ArrayForEach(f, sync_json)
       {
         cJSON* step_json = cJSON_GetObjectItem(f, "step");
         cJSON* fn_json   = cJSON_GetObjectItem(f, "fn");
@@ -484,21 +488,56 @@ bool ParseSystems(cJSON* root, game_t* out)
         SystemCB callback = (SystemCB)SystemFunctionLookup(fn_json->valuestring);
         if (!callback) continue;
 
-        if(step_json->valuestring[0] == 'U'){
         UpdateType step = GetUpdateStep(step_json->valuestring);
         if (step < 0 || step >= UPDATE_DONE)
           continue;
 
-          sys->steps[step] = callback;
-        }
-        else
-        {
-          GameState state = GetGameState(step_json->valuestring);
-          if (state >= 0 && state < GAME_DONE)
-            sys->states[state] = callback;
-        }
+          sys->syncs[step] = callback;
       }
     }
+    cJSON* state_json = cJSON_GetObjectItem(sys_item, "states");
+    if (cJSON_IsArray(state_json))
+    {
+      cJSON* f;
+      cJSON_ArrayForEach(f, state_json)
+      {
+        cJSON* step_json = cJSON_GetObjectItem(f, "step");
+        cJSON* fn_json   = cJSON_GetObjectItem(f, "fn");
+
+        if (!cJSON_IsString(step_json) || !cJSON_IsString(fn_json))
+          continue;
+
+        SystemCB callback = (SystemCB)SystemFunctionLookup(fn_json->valuestring);
+        if (!callback) continue;
+
+        GameState state = GetGameState(step_json->valuestring);
+        if (state >= 0 && state < GAME_DONE)
+          sys->states[state] = callback;
+      }
+    }
+
+    cJSON* steps_json = cJSON_GetObjectItem(sys_item, "steps");
+    if (cJSON_IsArray(steps_json))
+    {
+      cJSON* f;
+      cJSON_ArrayForEach(f, steps_json)
+      {
+        cJSON* step_json = cJSON_GetObjectItem(f, "step");
+        cJSON* fn_json   = cJSON_GetObjectItem(f, "fn");
+
+        if (!cJSON_IsString(step_json) || !cJSON_IsString(fn_json))
+          continue;
+
+        SystemFn callback = (SystemFn)SystemFunctionLookup(fn_json->valuestring);
+        if (!callback) continue;
+
+        UpdateType step = GetUpdateStep(step_json->valuestring);
+        if (step < 0 || step >= UPDATE_DONE)
+          sys->steps[step] = callback;
+      }
+    }
+
+
   }
 
   return true;
@@ -511,6 +550,10 @@ bool ParseComponents(cJSON* root, game_t* out){
     out->num_defs = Json_GetInt(root, "num_comp_def", NUM_COMP_CORE);
     out->comp_defs = GameCalloc("ParseComponents", out->num_defs, sizeof(component_entry_t));
 
+    int comps_present = cJSON_GetArraySize(comp_json);
+
+    if(comps_present > out->num_defs)
+      TraceLog(LOG_WARNING, " === ParseComponents === Num components capped at %i but %i present", out->num_defs, comps_present);
     cJSON* c;
     cJSON_ArrayForEach(c, comp_json){
       if (!cJSON_IsString(c))

--- a/src/game_physics.h
+++ b/src/game_physics.h
@@ -42,21 +42,6 @@ typedef enum{
   REACT_BLOCK,
 }ReactType;
 
-typedef struct{
-  const char     name[MAX_NAME_LEN];
-  ForceType      type;
-  float          speed, max_vel, threshold;
-  Vector2        frict;
-  PhysicsEventID event;
-  ReactType      react;
-}force_d;
-
-typedef struct{
-  const char  name[MAX_NAME_LEN];
-  ShapeType   shape;
-  int         wid, hei;
-}phys_d;
-
 force_t* ForceReactBump(rigid_body_t* a, rigid_body_t* b, force_t*);
 force_t* ForceReactBlock(rigid_body_t* a, rigid_body_t* b, force_t*);
 

--- a/src/game_register.h
+++ b/src/game_register.h
@@ -46,15 +46,13 @@ typedef struct {
   comp_id_t terms[MAX_TERMS];
   int       term_count;
   SystemFn  init;
+  SystemFn  step[UPDATE_DONE];
   SystemCB  set[GAME_DONE];
   SystemCB  tick[UPDATE_DONE];
   bool      needs_iter;
 } system_t;
 
 system_t* SystemRegister(world_t* w, SystemCB*, SystemCB*, SystemFn);
-
-void SystemTick(world_t* w, system_t* s, UpdateType u);
-void SystemSet(world_t* w, system_t* s, GameState g);
 
 static void SystemRequire(system_t* s, comp_id_t id) {
     s->terms[s->term_count++] = id;

--- a/src/game_registry.c
+++ b/src/game_registry.c
@@ -65,8 +65,13 @@ Entity PrefabInstantiate(world_t* w, Entity prefab, Vector2 override_pos) {
     void* src = ComponentGet(w, prefab, pool->id);
     void* dst = ComponentAdd(w, instance, pool->id);
 
-    if (src && dst)
+    if (src && dst){
       memcpy(dst, src, pool->elem_size);
+      char notif_str[MAX_NAME_LEN];
+      sprintf(notif_str, "ADD_NEW_%s", CORE_COMPONENTS[pool->id]);
+      notification n = GameNotification(notif_str);
+      GameEvent(n, dst, instance.id);
+    }
     else
       TraceLog(LOG_WARNING, "Unable to add Comp %i - %s to Ent: %i",
          pool->id, CORE_COMPONENTS[pool->id], instance.id);

--- a/src/game_registry.c
+++ b/src/game_registry.c
@@ -67,10 +67,6 @@ Entity PrefabInstantiate(world_t* w, Entity prefab, Vector2 override_pos) {
 
     if (src && dst){
       memcpy(dst, src, pool->elem_size);
-      char notif_str[MAX_NAME_LEN];
-      sprintf(notif_str, "ADD_NEW_%s", CORE_COMPONENTS[pool->id]);
-      notification n = GameNotification(notif_str);
-      GameEvent(n, dst, instance.id);
     }
     else
       TraceLog(LOG_WARNING, "Unable to add Comp %i - %s to Ent: %i",
@@ -78,11 +74,11 @@ Entity PrefabInstantiate(world_t* w, Entity prefab, Vector2 override_pos) {
   }
 
   // Apply overrides
-  if (override_pos.x != -9999.0f) {  // special value = no override
+  if(!vec_compare(override_pos, VEC_UNSET)) {
     position_t* pos = GET_COMPONENT(w, instance, position_t, POS_ID);
     rigid_body_t* rb = GET_COMPONENT(w, instance, rigid_body_t, PHYS_ID);
     
-    if (pos && !vec_compare(override_pos, VEC_UNSET)) {
+    if (pos){
       pos->vpos = override_pos;
       if(rb)
         RigidBodySetPos(rb, override_pos);

--- a/src/game_sprites.c
+++ b/src/game_sprites.c
@@ -80,6 +80,33 @@ void DrawSlice(sprite_slice_t *s, Vector2 position,float rot){
   return;
 }
 
+void DrawSprite(sprite_t* spr, Vector2 pos){
+  sprite_slice_t* s  = &SHEETS[spr->sheet_id].sprites[spr->index].slice;
+  Rectangle src = s->bounds;
+
+  Vector2 origin = (Vector2){
+    s->center.x * spr->scale,//offset.x,
+      s->center.y * spr->scale//offset.y
+  };
+
+  Vector2 position = Vector2Add(pos,s->center);
+  Rectangle dst = {
+    position.x,
+    position.y,
+    abs(s->bounds.width * spr->scale),
+    s->bounds.height * spr->scale
+  };
+
+  Texture sheet = SHEETS[s->sheet].texture;
+  Color col = s->color.a > 0? s->color: WHITE;
+  DrawTexturePro(sheet,src,dst, origin, spr->rot, col);
+
+  return;
+
+
+
+}
+
 void SpriteLoadSubTextures(sub_texture_t* data, SheetID id, int sheet_cap){
   /*
   for(int i = 0; i < sheet_cap;i++){

--- a/src/game_system.c
+++ b/src/game_system.c
@@ -1,81 +1,6 @@
 #include "game_define.h"
 #include "game_enum.h"
 
-void OnSystemEvent(event_t* ev, void* data){
-  system_t* s = data;
-  world_t*  w = ev->data;
-  switch((GameEventID)EVENT_ID(ev->type)){
-    case GAME_EVENT_STEP:
-      UpdateType u = ev->eid;
-      SystemTick(w, s, u);
-      break;
-    case GAME_EVENT_STATE:
-      GameState state = ev->eid;
-      SystemSet(w, s, state);
-      break;
-  }
-}
-
-system_t* SystemRegister(world_t* w, SystemCB tick[UPDATE_DONE], SystemCB set[GAME_DONE], SystemFn init){
-  system_t* s = &w->systems[w->num_sys];
-  memset(s, 0, sizeof(system_t));
-  s->index = w->num_sys++;
-  for (int i = 0; i < UPDATE_DONE; i++){
-    if(!tick[i])
-      continue;
-
-    s->tick[i] = tick[i];
-    uint64_t n = GameEvent_ToNotif(GAME_EVENT_STEP);
-    TargetSubscribe(n, OnSystemEvent, s, i);
-  }
-  for (int i = 0; i < GAME_DONE; i++){
-    if(!set[i])
-      continue;
-
-    s->set[i] = set[i];
-    uint64_t n = GameEvent_ToNotif(GAME_EVENT_STATE);
-    TargetSubscribe(n, OnSystemEvent, s, i);
-  }
-
-  s->init = init;
-  return s;
-}
-
-system_t* SystemCreate(world_t* w, system_define_t* def){
-  system_t* s = &w->systems[w->num_sys];
-  memset(s, 0, sizeof(system_t));
-  s->index = w->num_sys++;
-
-  for (int i = 0; i < UPDATE_DONE; i++){
-    if(!def->steps[i])
-      continue;
-
-    s->tick[i] = def->steps[i];
-    uint64_t n = GameEvent_ToNotif(GAME_EVENT_STEP);
-    TargetSubscribe(n, OnSystemEvent, s, i);
-  }
-
-  for (int i = 0; i < GAME_DONE; i++){
-    if(!def->states[i])
-      continue;
-
-    s->set[i] = def->states[i];
-    uint64_t n = GameEvent_ToNotif(GAME_EVENT_STATE);
-    TargetSubscribe(n, OnSystemEvent, s, i);
-  }
-
-  for (int i = 0; i < def->num_req; i++){
-    comp_id_t cid = ComponentGetID(def->components[i]);
-    if(cid != INVALID_COMPONENT)
-      SystemRequire(s, cid);
-
-  }
-  if(def->init)
-    s->init = def->init;
-
-  return s;
-}
-
 component_pool_t* ComponentQueryInner(world_t* w, system_t* s) {
   component_pool_t* best = NULL;
 
@@ -94,6 +19,13 @@ component_pool_t* ComponentQueryInner(world_t* w, system_t* s) {
   return best;
 }
 
+void SystemStep(world_t* w, system_t* s, UpdateType u){
+  if(!s->step[u])
+    return;
+
+  s->step[u](w);
+}
+ 
 void SystemTick(world_t* w, system_t* s, UpdateType u){
   if(!s->tick[u])
     return;
@@ -156,4 +88,95 @@ void SystemSet(world_t* w, system_t* s, GameState g){
     s->set[g](w, e);
   }
 
+}
+
+void OnSystemEvent(event_t* ev, void* data){
+  system_t* s = data;
+  world_t*  w = ev->data;
+  UpdateType u;
+  switch((GameEventID)EVENT_ID(ev->type)){
+    case GAME_EVENT_SYNC:
+      u = ev->eid;
+      SystemTick(w, s, u);
+      break;
+    case GAME_EVENT_STEP:
+      u = ev->eid;
+      SystemStep(w, s, u);
+      break;
+    case GAME_EVENT_STATE:
+      GameState state = ev->eid;
+      SystemSet(w, s, state);
+      break;
+  }
+}
+
+system_t* SystemRegister(world_t* w, SystemCB tick[UPDATE_DONE], SystemCB set[GAME_DONE], SystemFn init){
+  system_t* s = &w->systems[w->num_sys];
+  memset(s, 0, sizeof(system_t));
+  s->index = w->num_sys++;
+  for (int i = 0; i < UPDATE_DONE; i++){
+    if(!tick[i])
+      continue;
+
+    s->tick[i] = tick[i];
+    uint64_t n = GameEvent_ToNotif(GAME_EVENT_STEP);
+    TargetSubscribe(n, OnSystemEvent, s, i);
+  }
+  for (int i = 0; i < GAME_DONE; i++){
+    if(!set[i])
+      continue;
+
+    s->set[i] = set[i];
+    uint64_t n = GameEvent_ToNotif(GAME_EVENT_STATE);
+    TargetSubscribe(n, OnSystemEvent, s, i);
+  }
+
+  s->init = init;
+  return s;
+}
+
+system_t* SystemCreate(world_t* w, system_define_t* def){
+  system_t* s = &w->systems[w->num_sys];
+  memset(s, 0, sizeof(system_t));
+  s->index = w->num_sys++;
+
+  for (int i = 0; i < UPDATE_DONE; i++){
+    if(!def->syncs[i])
+      continue;
+
+    s->tick[i] = def->syncs[i];
+    uint64_t n = GameEvent_ToNotif(GAME_EVENT_SYNC);
+    TargetSubscribe(n, OnSystemEvent, s, i);
+  }
+
+  for (int i = 0; i < UPDATE_DONE; i++){
+    if(!def->steps[i])
+      continue;
+  
+    s->step[i] = def->steps[i];
+    uint64_t n = GameEvent_ToNotif(GAME_EVENT_STEP);
+    TargetSubscribe(n, OnSystemEvent, s, i);
+  }
+
+  for (int i = 0; i < GAME_DONE; i++){
+    if(!def->states[i])
+      continue;
+
+    s->set[i] = def->states[i];
+    uint64_t n = GameEvent_ToNotif(GAME_EVENT_STATE);
+    TargetSubscribe(n, OnSystemEvent, s, i);
+  }
+
+  for (int i = 0; i < def->num_req; i++){
+    comp_id_t cid = ComponentGetID(def->components[i]);
+    if(cid != INVALID_COMPONENT)
+      SystemRequire(s, cid);
+
+  }
+
+  if(def->init){
+    s->init = def->init;
+    s->init(w);
+  }
+  return s;
 }

--- a/src/game_system.c
+++ b/src/game_system.c
@@ -65,7 +65,6 @@ void SystemSet(world_t* w, system_t* s, GameState g){
   component_pool_t* base = ComponentQueryInner(w, s);
   if (!base) return;
 
-  //TraceLog(LOG_INFO,"CALL SYSTEM %i State %i at frame %i", s->index, g, WorldGetTime());
   for (int i = 0; i < base->size; i++) {
     Entity e = { base->entities[i], w->manager.generation[base->entities[i]] };
 

--- a/src/game_systems.h
+++ b/src/game_systems.h
@@ -12,7 +12,6 @@ void PositionLoad(world_t* w, Entity e);
 void AnimLoad(world_t* w, Entity e);
 //void AnimBehavior(world_t* w, Entity e);
 void AnimSystem(world_t* w, Entity e);
-void AnimRender(world_t* w, Entity e);
 
 void OnInputEvent(event_t* ev, void* data);
 void InputLoad(world_t* w, Entity e);
@@ -35,15 +34,21 @@ void LevelRender(world_t* w, Entity e);
 
 void RenderLoad(world_t* w, Entity e);
 void RenderBegin(world_t* w, Entity e);
+void RenderDraw(world_t* w, Entity e);
 void RenderEnd(world_t* w, Entity e);
-
-void CameraSystem(world_t* w, Entity e);
 
 void CameraLoad(world_t* w, Entity e);
 void CameraReady(world_t* w, Entity e);
+void CameraSystem(world_t* w, Entity e);
+void CameraBegin(world_t* w, Entity e);
+void CameraEnd(world_t* w, Entity e);
 
-void SpriteRender(world_t* w, Entity e);
-void SpriteLoad(world_t* w, Entity e);
+typedef struct{
+  int     count, cap;
+  int     *ents;
+}sprite_layer_t;
+
+void SpritesInit(world_t* w);
 
 void BehaviorSystem(world_t* w, Entity e);
 
@@ -65,7 +70,6 @@ static system_function_lookup_t FUNCTION_LOOKUP[NUM_FUNCTIONS] = {
 
     {"AnimLoad",            AnimLoad},
     {"AnimSystem",          AnimSystem},
-    {"AnimRender",          AnimRender},
 
     {"OnInputEvent",        OnInputEvent},
     {"InputLoad",           InputLoad},
@@ -85,23 +89,19 @@ static system_function_lookup_t FUNCTION_LOOKUP[NUM_FUNCTIONS] = {
     {"LevelLoad",           LevelLoad},
     {"LevelReady",          LevelReady},
     {"LevelSystem",         LevelSystem},
-    {"LevelRender",         LevelRender},
 
     {"RenderLoad",          RenderLoad},
     {"RenderBegin",         RenderBegin},
+    {"RenderDraw",         RenderDraw},
     {"RenderEnd",           RenderEnd},
 
     {"CameraSystem",        CameraSystem},
+    {"CameraBegin",         CameraBegin},
+    {"CameraEnd",           CameraEnd},
     {"CameraLoad",          CameraLoad},
     {"CameraReady",         CameraReady},
 
-    {"SpriteRender",        SpriteRender},
-
-    {"SpriteLoad",          SpriteLoad},
-
-    {"CombatLoad",          CombatLoad},
-    {"CombatSystem",        CombatSystem},
-
+    {"SpritesInit",         SpritesInit},
     {"ExpirationSystem",    ExpirationSystem}
 };
 

--- a/src/game_systems.h
+++ b/src/game_systems.h
@@ -49,7 +49,7 @@ typedef struct{
 }sprite_layer_t;
 
 void SpritesInit(world_t* w);
-
+void SpriteLoad(world_t* w, Entity e);
 void BehaviorSystem(world_t* w, Entity e);
 
 void CombatLoad(world_t* w, Entity e);
@@ -102,6 +102,7 @@ static system_function_lookup_t FUNCTION_LOOKUP[NUM_FUNCTIONS] = {
     {"CameraReady",         CameraReady},
 
     {"SpritesInit",         SpritesInit},
+    {"SpriteLoad",          SpriteLoad},
     {"ExpirationSystem",    ExpirationSystem}
 };
 

--- a/src/game_tools.h
+++ b/src/game_tools.h
@@ -205,7 +205,11 @@ static uint64_t hash_64_from_int(int x)
 
     return z;
 }
-
+static int int_from_hash_64(uint64_t h)
+{
+    h ^= h >> 32;
+    return (int)h;                    // simple and fast
+}
 static uint32_t hash_float(float f) {
     uint32_t bits;
     memcpy(&bits, &f, sizeof(float)); // safe bit copy

--- a/src/game_views.h
+++ b/src/game_views.h
@@ -6,6 +6,12 @@
 #define MAX_CAMERA 4
 
 #define TRACK(x, c, v)(x.fn(c, x, v))
+DEFINE_EVENT_SPACE(ViewEvent, EVENT_VIEW_BASE);
+typedef enum{
+  VIEW_EVENT_NONE,
+  VIEW_EVENT_DRAW,
+  VIEW_EVENT_COUNT
+}ViewEventID;
 
 typedef Camera2D camera_t;
 camera_t* InitCamera(float zoom, float rot, Vector2 offset);

--- a/src/game_views.h
+++ b/src/game_views.h
@@ -16,13 +16,6 @@ typedef enum{
 typedef Camera2D camera_t;
 camera_t* InitCamera(float zoom, float rot, Vector2 offset);
 
-typedef struct{
-  const char  name[MAX_NAME_LEN];
-  float       zoom, rot;
-  int         offset_x, offset_y, wid, hei;
-  int         bx, by, bw, bh;
-}cam_d;
-
 typedef enum{
   CAM_NONE,
   CAM_FOLLOW,
@@ -38,6 +31,7 @@ typedef enum{
 
 typedef struct{
   Rectangle       view, bounds, border;
+  Vector2         origin;
   float           border_distance;
   RenderTexture2D tex;
 }viewport_t;

--- a/src/game_world.c
+++ b/src/game_world.c
@@ -121,6 +121,7 @@ void InitGameProcess(){
   GP.update_steps[SCREEN_GAMEPLAY][UPDATE_FIXED] = FixedUpdate;
   GP.update_steps[SCREEN_GAMEPLAY][UPDATE_PRE] = PreUpdate;
   GP.update_steps[SCREEN_GAMEPLAY][UPDATE_DRAW_BEGIN] = BeginDraw;
+  GP.update_steps[SCREEN_GAMEPLAY][UPDATE_DRAW] = DrawGameplayScreen;
   GP.update_steps[SCREEN_GAMEPLAY][UPDATE_DRAW_END] = EndDraw;
   GP.update_steps[SCREEN_GAMEPLAY][UPDATE_FRAME] = UpdateGameplayScreen;
   GP.update_steps[SCREEN_GAMEPLAY][UPDATE_POST] = PostUpdate;

--- a/src/scene_loader.c
+++ b/src/scene_loader.c
@@ -36,6 +36,14 @@ bool SceneInit(LoadQueue* l){
 }
 
 void SceneSetup(world_t* w, Scene* s){
+  for(int i = 0; i < s->entity_count; i++){
+    entity_instance_t e = s->entities[i];
+
+    Vector2 pos = VEC_NEW(e.x, e.y);
+    Entity spawn = PrefabSpawn(w, e.prefab, pos);
+
+  }
+
   for(int i = 0; i < s->tile_count; i++){
     tile_instance_t t = s->tiles[i];
     Entity tile = PrefabSpawn(w, t.name, VEC_UNSET);
@@ -46,11 +54,4 @@ void SceneSetup(world_t* w, Scene* s){
     PositionSet(p, pos);
   }
 
-  for(int i = 0; i < s->entity_count; i++){
-    entity_instance_t e = s->entities[i];
-
-    Vector2 pos = VEC_NEW(e.x, e.y);
-    Entity spawn = PrefabSpawn(w, e.prefab, pos);
-
-  }
 }

--- a/src/system_anim.c
+++ b/src/system_anim.c
@@ -119,34 +119,16 @@ void AnimLoad(world_t* w, Entity e){
 
 void AnimSystem(world_t* w, Entity e){
   anim_comp_t* ac = GET_COMPONENT(w, e, anim_comp_t, ANIM_ID);
+  sprite_t* spr = GET_COMPONENT(w, e, sprite_t, SPR_ID);
   anim_player_t* ap = &ac->player;
   anim_t* a = &ac->sequences[ap->state][ap->dir];
-  position_t* pos = GET_COMPONENT(w, e, position_t, POS_ID);
 
   int spr_index = a->frames[a->cur_index];
+
+  spr->index = spr_index;
 
   AnimEventID ev = AnimPlay(a);
 
   ac->event = ev;
   AnimBehaviorHandler(w, e, ac, a);
-}
-
-void AnimRender(world_t* w, Entity e){
-  anim_comp_t* ac = GET_COMPONENT(w, e, anim_comp_t, ANIM_ID);
-  position_t*  pos = GET_COMPONENT(w, e, position_t, POS_ID);
-
-  anim_player_t* ap = &ac->player;
-
-  anim_t* a = &ac->sequences[ap->state][ap->dir];
-
-  if(!a)
-    return;
-
-  int spr_index = a->frames[a->cur_index];
-
-  sprite_slice_t* spr = &SHEETS[ap->sheet_id].sprites[spr_index].slice;
-  if(!spr)
-    return;
-
-  DrawSlice(spr, pos->vpos, 0);
 }

--- a/src/system_camera.c
+++ b/src/system_camera.c
@@ -59,12 +59,12 @@ void CameraBegin(world_t* w, Entity e){
   camera_t* c = GET_COMPONENT(w, e, camera_t, CAM_ID);
   BeginDrawing();
   ClearBackground(BLACK);
-  BeginMode2D(*c);
+//  BeginMode2D(*c);
 }
 
 void CameraEnd(world_t* w, Entity e){
   //camera_t* c = GET_COMPONENT(w, e, camera_t, CAM_ID);
-  EndMode2D();
+  //EndMode2D();
   DrawFPS(10,10);
   EndDrawing();
 }

--- a/src/system_camera.c
+++ b/src/system_camera.c
@@ -26,7 +26,7 @@ void CameraReady(world_t* w, Entity e){
 }
 
 void CameraSystem(world_t* w, Entity e){
-  cam_comp_t* c = GET_COMPONENT(w, e, cam_comp_t, CAM_ID);
+  camera_t* c = GET_COMPONENT(w, e, camera_t, CAM_ID);
   track_comp_t* t = GET_COMPONENT(w, e, track_comp_t, TRACK_ID);
 
   if(!t || !t->target)
@@ -42,8 +42,8 @@ void CameraSystem(world_t* w, Entity e){
   if(!pos)
     return;
 
-  TRACK(t->ctx.tracking, &c->camera, pos->vpos);
-
+  TRACK(t->ctx.tracking, c, pos->vpos);
+/*
   Rectangle cropped_bounds = RECT_CROP(c->view.border, c->view.border_distance);
 
   Vector2 clamped = clamp_point_to_rect(c->camera.target, cropped_bounds);
@@ -52,4 +52,20 @@ void CameraSystem(world_t* w, Entity e){
     return;
 
   c->camera.target = clamped;
+  */
 }
+
+void CameraBegin(world_t* w, Entity e){
+  camera_t* c = GET_COMPONENT(w, e, camera_t, CAM_ID);
+  BeginDrawing();
+  ClearBackground(BLACK);
+  BeginMode2D(*c);
+}
+
+void CameraEnd(world_t* w, Entity e){
+  //camera_t* c = GET_COMPONENT(w, e, camera_t, CAM_ID);
+  EndMode2D();
+  DrawFPS(10,10);
+  EndDrawing();
+}
+

--- a/src/system_render.c
+++ b/src/system_render.c
@@ -5,23 +5,19 @@ void RenderLoad(world_t* w, Entity e){
 }
 
 void RenderBegin(world_t* w, Entity e){
-  cam_comp_t* c = GET_COMPONENT(w, e, cam_comp_t, CAM_ID);
 
-  BeginDrawing();
-  BeginTextureMode(c->view.tex);
-  ClearBackground(BLACK);
-  BeginMode2D(c->camera);
-  GameEvent(GameEvent_ToNotif(GAME_EVENT_STEP), &world , UPDATE_DRAW);
+}
+
+void RenderDraw(world_t* w, Entity e){
+  view_comp_t* vc = GET_COMPONENT(w, e, view_comp_t, VIEW_ID);
+  BeginTextureMode(vc->view.tex);
+
+  notification n = ViewEvent_ToNotif(VIEW_EVENT_DRAW);
+  GameEvent(n, vc, vc->layer);
+  EndTextureMode();
+  DrawTexturePro(vc->view.tex.texture, vc->view.view, vc->view.bounds, VECTOR2_ZERO, 0, WHITE);
 
 }
 
 void RenderEnd(world_t* w, Entity e){
-  cam_comp_t* c = GET_COMPONENT(w, e, cam_comp_t, CAM_ID);
-  EndMode2D();
-  EndTextureMode();
-  DrawTexturePro(c->view.tex.texture, c->view.view, c->view.bounds, VECTOR2_ZERO, 0, WHITE);
-
-  DrawFPS(10,10);
-  EndDrawing();
-
 }

--- a/src/system_render.c
+++ b/src/system_render.c
@@ -15,7 +15,7 @@ void RenderDraw(world_t* w, Entity e){
   notification n = ViewEvent_ToNotif(VIEW_EVENT_DRAW);
   GameEvent(n, vc, vc->layer);
   EndTextureMode();
-  DrawTexturePro(vc->view.tex.texture, vc->view.view, vc->view.bounds, VECTOR2_ZERO, 0, WHITE);
+  DrawTexturePro(vc->view.tex.texture, vc->view.view, vc->view.bounds, vc->view.origin, 0, WHITE);
 
 }
 

--- a/src/system_sprite.c
+++ b/src/system_sprite.c
@@ -3,20 +3,6 @@
 
 static sprite_layer_t SPRITE_LAYERS[LAYER_DONE] = {0};
 
-void SpriteComponentEvent(event_t* ev, void* data){
-  world_t* w = data;
-  sprite_t*  spr = ev->data;
-
-  if(spr->layer < LAYER_BG || spr->layer >= LAYER_DONE){
-    TraceLog(LOG_WARNING, "==== SPRITE COMPONENT EVENT ===\n Ent %i invalid sprite layer %i", ev->eid, spr->layer);
-    return;
-  }
-
-  int *slot = &SPRITE_LAYERS[spr->layer].ents[SPRITE_LAYERS[spr->layer].count++];
-
-  *slot = ev->eid;
-}
-
 void SpriteRender(world_t* w, RenderLayer l){
   sprite_layer_t sprl = SPRITE_LAYERS[l];
 
@@ -25,12 +11,7 @@ void SpriteRender(world_t* w, RenderLayer l){
     sprite_t* s      = GET_COMPONENT(w, e, sprite_t, SPR_ID);
     position_t* pos  = GET_COMPONENT(w, e, position_t, POS_ID);
 
-
-    sprite_slice_t* slice = &SHEETS[s->sheet_id].sprites[s->index].slice;
-    if(!slice)
-      continue;
-
-    DrawSlice(slice, pos->vpos, 0);
+    DrawSprite(s, pos->vpos);
   }
 }
 
@@ -40,12 +21,22 @@ void SpriteViewEvent(event_t* ev, void* data){
   SpriteRender(w, ev->eid);
 }
 
+void SpriteLoad(world_t* w, Entity e){
+  sprite_t* s      = GET_COMPONENT(w, e, sprite_t, SPR_ID);
+  
+  if(s->layer < LAYER_BG || s->layer >= LAYER_DONE){
+    TraceLog(LOG_WARNING, "==== SPRITE LOAD ===\n Ent %i invalid sprite layer %i", e.id, s->layer);
+    return;
+  }
+
+  int *slot = &SPRITE_LAYERS[s->layer].ents[SPRITE_LAYERS[s->layer].count++];
+
+  *slot = e.id;
+
+}
+
 void SpritesInit(world_t* w){
   notification n = ViewEvent_ToNotif(VIEW_EVENT_DRAW);
-
-  n = GameNotification("ADD_NEW_Sprite");
-  Subscribe(n, SpriteComponentEvent, w);
-  n = ViewEvent_ToNotif(VIEW_EVENT_DRAW);
 
   for(int i = 0; i < LAYER_DONE; i++){
     SPRITE_LAYERS[i].cap = MAX_LAYER_SPRITES;

--- a/src/system_sprite.c
+++ b/src/system_sprite.c
@@ -1,18 +1,58 @@
 #include "game_assets.h"
 #include "game_systems.h"
 
-void SpriteLoad(world_t* w, Entity e){
+static sprite_layer_t SPRITE_LAYERS[LAYER_DONE] = {0};
 
-}
+void SpriteComponentEvent(event_t* ev, void* data){
+  world_t* w = data;
+  sprite_t*  spr = ev->data;
 
-void SpriteRender(world_t* w, Entity e){
-  sprite_t* s      = GET_COMPONENT(w, e, sprite_t, SPR_ID);
-  position_t* pos  = GET_COMPONENT(w, e, position_t, POS_ID);
-
-
-  sprite_slice_t* slice = &SHEETS[s->sheet_id].sprites[s->index].slice;
-  if(!slice)
+  if(spr->layer < LAYER_BG || spr->layer >= LAYER_DONE){
+    TraceLog(LOG_WARNING, "==== SPRITE COMPONENT EVENT ===\n Ent %i invalid sprite layer %i", ev->eid, spr->layer);
     return;
+  }
 
-  DrawSlice(slice, pos->vpos, 0);
+  int *slot = &SPRITE_LAYERS[spr->layer].ents[SPRITE_LAYERS[spr->layer].count++];
+
+  *slot = ev->eid;
 }
+
+void SpriteRender(world_t* w, RenderLayer l){
+  sprite_layer_t sprl = SPRITE_LAYERS[l];
+
+  for (int j = 0; j < sprl.count; j++){
+    Entity e = EntityGet(&w->manager, sprl.ents[j]); 
+    sprite_t* s      = GET_COMPONENT(w, e, sprite_t, SPR_ID);
+    position_t* pos  = GET_COMPONENT(w, e, position_t, POS_ID);
+
+
+    sprite_slice_t* slice = &SHEETS[s->sheet_id].sprites[s->index].slice;
+    if(!slice)
+      continue;
+
+    DrawSlice(slice, pos->vpos, 0);
+  }
+}
+
+void SpriteViewEvent(event_t* ev, void* data){
+  world_t* w = data;
+
+  SpriteRender(w, ev->eid);
+}
+
+void SpritesInit(world_t* w){
+  notification n = ViewEvent_ToNotif(VIEW_EVENT_DRAW);
+
+  n = GameNotification("ADD_NEW_Sprite");
+  Subscribe(n, SpriteComponentEvent, w);
+  n = ViewEvent_ToNotif(VIEW_EVENT_DRAW);
+
+  for(int i = 0; i < LAYER_DONE; i++){
+    SPRITE_LAYERS[i].cap = MAX_LAYER_SPRITES;
+    SPRITE_LAYERS[i].ents = GameCalloc("SpritesInit",
+        MAX_LAYER_SPRITES, sizeof(int));
+    
+    TargetSubscribe(n, SpriteViewEvent, w, i);
+  }
+}
+


### PR DESCRIPTION
### What does this PR do?

- Added a full **Render Layer** system with `RenderLayer` enum and per-entity layer support.
- Integrated layer-aware rendering in `SpriteRender` / `AnimRender` systems with proper sorting.
- Implemented flexible **asset loading** infrastructure (spritesheets, animations, etc.).
- Added support for loading component-specific assets via the new `"func"` fields in component definitions.
- Refactored rendering pipeline to be more modular and extensible.

### Key Changes

- New System functions "step", system_t refactored to-
```
  SystemFn  init;
  SystemFn  step[UPDATE_DONE];
  SystemCB  set[GAME_DONE];
  SystemCB  tick[UPDATE_DONE];
```

- New `RenderLayer` enum (`BACKGROUND`, `TILES`, `OBJECTS`, `ENTITIES`, `PARTICLES`, `UI`, etc.)
- Moving some fields from sprite_slice to sprite_ (example scale),
- Added `layer` fields to relevant components (Sprite, Animation, etc.)
- Improved `ParseComponentDefinitions()` to handle asset init functions
- Better organization of asset loading (`SpriteInit`, `AnimInit`, etc.)
- Minor cleanups and bug fixes in game definition parsing

### Why?

This gives us proper control over draw order and prepares the engine for advanced rendering features like parallax, lighting layers, post-processing per layer, and clean UI separation.

---

**Ready for review & merge.**