### PR TITLE
fixed issues with missing anim_t booleans as well as render layer not

### DIFF
--- a/resources/data/definitions.json
+++ b/resources/data/definitions.json
@@ -1,9 +1,9 @@
 {
-  "num_comp_def": 22,
+  "num_comp_def": 23,
   "components": [
-    "Sprite", "Animation", "View", "Position", "Input", "Camera"
+    "RigidBody", "Force", "Sprite", "Animation", "View", "Position", "Input", "Camera"
   ],
-  "systems": ["Animations", "Sprites", "Cameras", "Render"],
+  "systems": ["Physics", "Controller", "Animations", "Sprites", "Cameras", "Render"],
   "Animations":{
     "components": ["Animation", "Sprite"],
     "syncs": [
@@ -123,7 +123,7 @@
     "list": [
       {"name": "player", "sheet_id": "SHEET_CHAR",
         "states": [
-          {"state": "WALK", "loop": false, "end": "SUPSEND",
+          {"state": "WALK", "interupt": true, "loop": false, "end": "SUPSEND",
             "sequences": [
               {"tag": "walk0",   "dir": 0},
               {"tag": "walk90",  "dir": 1},
@@ -131,7 +131,7 @@
               {"tag": "walk270", "dir": 3}
             ]
           },
-          {"state": "IDLE", "loop": true,
+          {"state": "IDLE","interupt": true, "loop": true,
             "sequences": [
               {"tag": "idle0",   "dir": 0},
               {"tag": "idle90",  "dir": 1},
@@ -139,8 +139,8 @@
               {"tag": "idle270", "dir": 3}
             ]
           },
-          {"state": "ATTACK", "loop": false,
-            "end": "SUSPEND", "start": "HURTBOX",
+          {"state": "ATTACK",
+            "end": "SUSPEND", "start": "HURTBOX", 
             "sequences": [
               {"tag": "attack0",   "dir": 0},
               {"tag": "attack90",  "dir": 1},
@@ -253,8 +253,8 @@
       },
       {
         "name": "player",
-        "count": 3,
-        "list": ["Sprite", "Animation", "Position"]
+        "count": 4,
+        "list": ["Input", "Sprite", "Animation", "Position"]
       },
       {
         "name": "tile",

--- a/resources/data/definitions.json
+++ b/resources/data/definitions.json
@@ -123,7 +123,7 @@
     "list": [
       {"name": "player", "sheet_id": "SHEET_CHAR",
         "states": [
-          {"state": "WALK", "interupt": true, "loop": false, "end": "SUPSEND",
+          {"state": "WALK", "interupt": true, "loop": false, "end": "SUSPEND",
             "sequences": [
               {"tag": "walk0",   "dir": 0},
               {"tag": "walk90",  "dir": 1},

--- a/src/game.c
+++ b/src/game.c
@@ -54,7 +54,6 @@ void BeginDraw(void){
 }
 
 void DrawGameplayScreen(void){
-
   GameEvent(GameEvent_ToNotif(GAME_EVENT_STEP), &world , UPDATE_DRAW);
   GameEvent(GameEvent_ToNotif(GAME_EVENT_SYNC), &world , UPDATE_DRAW);
 }

--- a/src/game_enum.h
+++ b/src/game_enum.h
@@ -3,13 +3,14 @@
 
 #define BIT64(n) (1ULL << (n))
 
-#define EVENT_INPUT_BASE  0x1000
-#define EVENT_GAME_BASE   0x2000
-#define EVENT_PHYS_BASE   0x3000
-#define EVENT_POS_BASE    0x4000
-#define EVENT_ANIM_BASE   0x5000
-#define EVENT_VIEW_BASE   0x6000
-#define EVENT_COMBAT_BASE 0x7000
+#define EVENT_INPUT_BASE      0x1000
+#define EVENT_GAME_BASE       0x2000
+#define EVENT_PHYS_BASE       0x3000
+#define EVENT_POS_BASE        0x4000
+#define EVENT_ANIM_BASE       0x5000
+#define EVENT_VIEW_BASE       0x6000
+#define EVENT_PARTICLE_BASE   0x7000
+#define EVENT_COMBAT_BASE     0x8000
 #define EVENT_BASE_MASK   0xFFFFF000
 #define EVENT_ID_MASK     0x00000FFF
 

--- a/src/game_parse.c
+++ b/src/game_parse.c
@@ -38,6 +38,14 @@ bool Json_GetBool(cJSON* obj, const char* key){
   return item->valueint != 0;;
 }
 
+AnimBehavior StringToAnimBehavior(char* str){
+ if (strcmp(str, "BLANK") == 0) return ANIM_BLANK;
+ if (strcmp(str, "SUSPEND") == 0) return ANIM_SUSPEND;
+ if (strcmp(str, "HURTBOX") == 0) return ANIM_HURTBOX;
+
+ return ANIM_BLANK;
+}
+
 AnimState StringToAnimState(char* str){
  if (strcmp(str, "IDLE") == 0) return ANIM_IDLE;
  if (strcmp(str, "WALK") == 0) return ANIM_WALK;
@@ -103,6 +111,15 @@ bool ParseAnimComponent(cJSON* j, anim_comp_t* out){
     Json_GetString(s, "state", state_str);
 
     bool loop = Json_GetBool(s, "loop");
+    bool interupt = Json_GetBool(s, "interupt");
+    char end_str[MAX_NAME_LEN];
+    Json_GetString(s, "end", end_str);
+    AnimBehavior on_end = StringToAnimBehavior(end_str); 
+
+    char start_str[MAX_NAME_LEN];
+    Json_GetString(s, "start", start_str);
+    AnimBehavior on_start = StringToAnimBehavior(start_str);
+
     AnimState state = StringToAnimState(state_str);
     if(state == ANIM_NONE){
       TraceLog(LOG_WARNING,"=== PARSE ANIM COMP ===\n unable to find state %s for prefab %s", state_str, name);
@@ -117,9 +134,25 @@ bool ParseAnimComponent(cJSON* j, anim_comp_t* out){
       char tag[MAX_NAME_LEN];
       Json_GetString(seq, "tag", tag);
       out->sequences[state][dir] = *AnimRegisterState(sheet_id, name, tag);
+      out->sequences[state][dir].loop = loop;
+      out->sequences[state][dir].interupt = interupt;
+      out->sequences[state][dir].on_end = on_end;
     }  
   }
 
+  sprite_sheet_d sh = SHEETS[sheet_id];
+  for(int i = 0; i < MAX_SLICES; i++){
+    collision_d cd = sh.coll[i];
+
+    switch(cd.type){
+      case COL_HIT:
+        out->hitbox = cd;
+        break;
+      default:
+        continue;
+        break;
+    }
+  }
   return sheet_id > -1;
 }
 

--- a/src/system_camera.c
+++ b/src/system_camera.c
@@ -58,12 +58,11 @@ void CameraSystem(world_t* w, Entity e){
 void CameraBegin(world_t* w, Entity e){
   camera_t* c = GET_COMPONENT(w, e, camera_t, CAM_ID);
   BeginDrawing();
-  ClearBackground(BLACK);
 //  BeginMode2D(*c);
 }
 
 void CameraEnd(world_t* w, Entity e){
-  //camera_t* c = GET_COMPONENT(w, e, camera_t, CAM_ID);
+  camera_t* c = GET_COMPONENT(w, e, camera_t, CAM_ID);
   //EndMode2D();
   DrawFPS(10,10);
   EndDrawing();

--- a/src/system_camera.c
+++ b/src/system_camera.c
@@ -58,12 +58,13 @@ void CameraSystem(world_t* w, Entity e){
 void CameraBegin(world_t* w, Entity e){
   camera_t* c = GET_COMPONENT(w, e, camera_t, CAM_ID);
   BeginDrawing();
-//  BeginMode2D(*c);
+  BeginMode2D(*c);
+  ClearBackground(BLANK);
 }
 
 void CameraEnd(world_t* w, Entity e){
   camera_t* c = GET_COMPONENT(w, e, camera_t, CAM_ID);
-  //EndMode2D();
+  EndMode2D();
   DrawFPS(10,10);
   EndDrawing();
 }

--- a/src/system_input.c
+++ b/src/system_input.c
@@ -24,7 +24,7 @@ void InputLoad(world_t* w, Entity e){
   position_t* p = GET_COMPONENT(w, e, position_t, POS_ID);
 
   notification n = InputEvent_ToNotif(INPUT_EVENT_MOVE);
-  TargetSubscribe(n, OnInputEvent, &p, e.id );
+  TargetSubscribe(n, OnInputEvent, p, e.id );
 
   n = InputEvent_ToNotif(INPUT_EVENT_BINDING);
   for(int i = 0; i < ACT_DONE; i++){

--- a/src/system_render.c
+++ b/src/system_render.c
@@ -1,13 +1,10 @@
 #include "game_systems.h"
 
-static bool clear = true;
-
 void RenderLoad(world_t* w, Entity e){
 
 }
 
 void RenderBegin(world_t* w, Entity e){
-  view_comp_t* vc = GET_COMPONENT(w, e, view_comp_t, VIEW_ID);
 }
 
 void RenderDraw(world_t* w, Entity e){
@@ -22,5 +19,4 @@ void RenderDraw(world_t* w, Entity e){
 }
 
 void RenderEnd(world_t* w, Entity e){
-  view_comp_t* vc = GET_COMPONENT(w, e, view_comp_t, VIEW_ID);
 }

--- a/src/system_render.c
+++ b/src/system_render.c
@@ -1,23 +1,26 @@
 #include "game_systems.h"
 
+static bool clear = true;
+
 void RenderLoad(world_t* w, Entity e){
 
 }
 
 void RenderBegin(world_t* w, Entity e){
-
+  view_comp_t* vc = GET_COMPONENT(w, e, view_comp_t, VIEW_ID);
 }
 
 void RenderDraw(world_t* w, Entity e){
   view_comp_t* vc = GET_COMPONENT(w, e, view_comp_t, VIEW_ID);
   BeginTextureMode(vc->view.tex);
+  ClearBackground(BLANK);
 
   notification n = ViewEvent_ToNotif(VIEW_EVENT_DRAW);
   GameEvent(n, vc, vc->layer);
   EndTextureMode();
   DrawTexturePro(vc->view.tex.texture, vc->view.view, vc->view.bounds, vc->view.origin, 0, WHITE);
-
 }
 
 void RenderEnd(world_t* w, Entity e){
+  view_comp_t* vc = GET_COMPONENT(w, e, view_comp_t, VIEW_ID);
 }


### PR DESCRIPTION

Fixed animation parsing issues + render layer handling

- Fixed missing boolean fields in anim_seq_d / animation state parsing (interupt and loop were not always read from JSON).
- Updated JSON animation definitions (player states) to explicitly include the new interupt field.
- Improved ParseAnimComponent() to correctly handle optional fields and defaults.
- Fixed render layer registration / component ordering after recent physics + particle system additions.
- Minor cleanup: updated component counts, system lists, and event base offsets for the new particle system.

This resolves broken animation transitions (especially WALK/IDLE/ATTACK states) and ensures proper layering when multiple systems are active.


