### PR TITLE
Bug/render pipeline texture offsets

### DIFF
--- a/resources/data/system_def.json
+++ b/resources/data/system_def.json
@@ -24,8 +24,7 @@
   "Animations":{
     "components": ["Animation", "Sprite"],
     "syncs": [
-      {"step": "UPDATE_FIXED",  "fn": "AnimSystem"},
-      {"step": "UPDATE_DRAW",  "fn": "AnimRender"}
+      {"step": "UPDATE_FIXED",  "fn": "AnimSystem"}
     ],
     "sets": [
       {"step": "GAME_LOADING",  "fn": "AnimLoad"},
@@ -42,6 +41,9 @@
     ],
     "states": [
       {"step": "GAME_RUNNING", "fn": "SpritesInit"}
+    ],
+    "steps": [
+      {"step": "UPDATE_DRAW_BEGIN", "fn": "SpriteDrawPrep"}
     ]
   },
   "Particles": {
@@ -88,8 +90,7 @@
     "components": ["RigidBody", "Position"],
     "syncs": [
       {"step": "UPDATE_POST",  "fn": "PhysicsSystem"},
-      {"step": "UPDATE_PRE" ,  "fn": "PhysicsCollision"},
-      {"step": "UPDATE_DRAW" ,  "fn": "PhysicsDebug"}
+      {"step": "UPDATE_PRE" ,  "fn": "PhysicsCollision"}
     ],
     "sets": [
       {"step": "GAME_READY",   "fn": "PhysicsLoad"}

--- a/src/asset_define.h
+++ b/src/asset_define.h
@@ -5,13 +5,11 @@
 #include "game_resources.h"
 #include "game_utils.h"
 #include "game_types.h"
+#include "sprite_enum.h"
 
-#define MAX_LAYER_SPRITES  128 
+#define MAX_LAYER_SPRITES  256 
 #define FLOAT_TEXT_SIZE    54
 #define FLOAT_TEXT_SPACING 2
-
-#define EVENT_ANIM_BASE     0x5000
-#define EVENT_PARTICLE_BASE 0x6000
 
 typedef struct{
   Vector2     offset;
@@ -25,18 +23,6 @@ static void SpriteUnloadSplash(void){
 
 }
 
-DEFINE_EVENT_SPACE(AnimEvent, EVENT_ANIM_BASE);
-
-typedef enum{
-  ANIM_EVENT_NONE,
-  ANIM_EVENT_FRAME,
-  ANIM_EVENT_FRAME_START,
-  ANIM_EVENT_FRAME_END,
-  ANIM_EVENT_SEQ_END,
-  ANIM_EVENT_ATTACK,
-  ANIM_EVENT_COUNT
-}AnimEventID;
-
 typedef struct sprite_s sprite_t;
 typedef struct sprite_slice_s sprite_slice_t;
 
@@ -45,16 +31,6 @@ bool IsHitboxActive(const ase_sprite_sheet_d* sheet, int frame);
 Rectangle GetHurtbox(const ase_sprite_sheet_d* sheet, int frame);
 
 void InitResources();
-
-typedef enum{
-  LAYER_ROOT = -1,
-  LAYER_BG,
-  LAYER_FLOOR,
-  LAYER_MAIN,
-  LAYER_TOP,
-  LAYER_UI,
-  LAYER_DONE
-}RenderLayer;
 
 typedef struct{
   char        name[MAX_NAME_LEN];
@@ -100,23 +76,6 @@ void AnimCollisionHurt(sprite_slice_t*,collision_d*, position_t*);
 
 typedef struct anim_player_s anim_player_t;
 typedef struct anim_s anim_t;
-
-typedef enum{
-  ANIM_NONE,
-  ANIM_START,
-  ANIM_IDLE,
-  ANIM_WALK,
-  ANIM_ATTACK,
-  ANIM_HURT,
-  ANIM_DIE,
-  ANIM_DONE
-}AnimState;
-
-typedef enum{
-  ANIM_BLANK,
-  ANIM_SUSPEND,
-  ANIM_HURTBOX,
-}AnimBehavior;
 
 typedef struct{
   AnimState   state;

--- a/src/game_load.c
+++ b/src/game_load.c
@@ -3,6 +3,8 @@
 #include "gbm_paths.h"
 #include "asset_define.h"
 #include "system_define.h"
+#include "util_parse.h"
+#include "tool_lookup.h"
 
 static ResourcePool RES_POOL;
 static cJSON* comp;
@@ -60,6 +62,36 @@ void AsepriteToSprite(SheetID id, const ase_sprite_sheet_d* ase, int index, spri
 
 }
 
+void ParseHitboxFromAseprite(cJSON* s, cJSON* k, collision_d* out, cJSON* f)
+{
+    cJSON* bounds = cJSON_GetObjectItem(k, "bounds");
+    if (!bounds) return;
+
+    char sname[MAX_NAME_LEN];
+
+    Json_GetString(s, "name", sname);    
+    out->type = StringToCollType(sname);
+
+    out->frame = Json_GetInt(k, "frame", -1);
+    out->shape = SHAPE_REC;
+    // Raw slice position (relative to trimmed frame)
+    float slice_x = cJSON_GetObjectItem(bounds, "x")->valuedouble;
+    float slice_y = cJSON_GetObjectItem(bounds, "y")->valuedouble;
+    float slice_w = cJSON_GetObjectItem(bounds, "w")->valuedouble;
+    float slice_h = cJSON_GetObjectItem(bounds, "h")->valuedouble;
+
+    // Get sprite trim offset
+    cJSON* srcSize = cJSON_GetObjectItem(f, "spriteSourceSize");
+    float trim_x = cJSON_GetObjectItem(srcSize, "x")->valuedouble;
+    float trim_y = cJSON_GetObjectItem(srcSize, "y")->valuedouble;
+
+    // Convert to sprite-local coordinates
+    out->x     = slice_x - trim_x;
+    out->y     = slice_y - trim_y;
+    out->wid   = slice_w;
+    out->hei   = slice_h;
+}
+
 void ResourceMapAsepriteAnims(SheetID id, sprite_sheet_d* s, ase_sprite_sheet_d* ase){
   for(int i = 0; i < ase->num_tags ; i++){
     anim_tag_t tag = ase->tags[i];
@@ -69,14 +101,23 @@ void ResourceMapAsepriteAnims(SheetID id, sprite_sheet_d* s, ase_sprite_sheet_d*
     }
   }
 
-  for (int i = 0; i < ase->num_slices; i++){
-    slice_d sdat = ase->slices[i];
-    for (int j = 0; j < sdat.num_keys; j++){
-      slice_key_t skdat = sdat.keys[j];
+  if(!ase->frame_meta || !ase->slice_meta)
+    return;
 
-      anim_frame_t* f = &ase->frames[skdat.frame];
-      s->coll[s->num_coll++] = *InitSpriteCollision(f, skdat.type,
-          SHAPE_REC, skdat.bounds);
+  cJSON* slice;
+  cJSON_ArrayForEach(slice, ase->slice_meta){
+    cJSON* keys = cJSON_GetObjectItem(slice, "keys");
+    cJSON* key;
+    cJSON_ArrayForEach(key, keys){
+      int fidx = Json_GetInt(key, "frame", -1);
+      if( fidx == -1)
+        continue;
+
+      cJSON* frame = cJSON_GetArrayItem(ase->frame_meta, fidx);
+      if(!frame)
+        continue;
+
+      ParseHitboxFromAseprite(slice, key, &s->coll[s->num_coll++], frame);
     }
   }
 }

--- a/src/game_parse.c
+++ b/src/game_parse.c
@@ -382,7 +382,8 @@ bool LoadAsepriteSheet(cJSON* root, ase_sprite_sheet_d* sheet){
   // ====================== PARSE FRAMES ======================
   cJSON* frames_json = cJSON_GetObjectItem(root, "frames");
   sheet->num_frames = cJSON_GetArraySize(frames_json);
-
+ 
+  sheet->frame_meta = cJSON_Duplicate(frames_json, true); 
   for (int i = 0; i < sheet->num_frames && i < MAX_SPRITE_FRAMES; i++) {
     cJSON* f = cJSON_GetArrayItem(frames_json, i);
     anim_frame_t* frame = &sheet->frames[i];
@@ -411,6 +412,7 @@ bool LoadAsepriteSheet(cJSON* root, ase_sprite_sheet_d* sheet){
   cJSON* slices_json = cJSON_GetObjectItem(meta, "slices");
   sheet->num_slices = cJSON_GetArraySize(slices_json);
 
+  sheet->slice_meta = cJSON_Duplicate(slices_json, true); 
   for (int i = 0; i < sheet->num_slices && i < MAX_ANIM_FRAMES; i++) {
     cJSON* s = cJSON_GetArrayItem(slices_json, i);
     slice_d* slice = &sheet->slices[i];
@@ -634,7 +636,9 @@ bool ParseSystems(cJSON* root, game_t* out){
 
         UpdateType step = GetUpdateStep(step_json->valuestring);
         if (step < 0 || step >= UPDATE_DONE)
-          sys->steps[step] = callback;
+          continue;
+
+        sys->steps[step] = callback;
       }
     }
   

--- a/src/game_resources.h
+++ b/src/game_resources.h
@@ -2,6 +2,7 @@
 #define __GAME_RES__
 #include "cJSON.h"
 #include "game_common.h"
+#include "sprite_enum.h"
 
 #define MAX_RESOURCES     4
 #define MAX_SPRITES       128
@@ -12,23 +13,6 @@
 
 cJSON* ParseRoot(const char* path);
 
-typedef enum{
-  SHEET_UI,
-  SHEET_ICON,
-  SHEET_TILE,
-  SHEET_CHAR,
-  SHEET_MOB,
-  SHEET_OBJ,
-  SHEET_VFX,
-  SHEET_ALL
-}SheetID;
-
-typedef enum{
-  COL_NONE,
-  COL_HIT,
-  COL_HURT,
-}CollType;
-  
 typedef struct{
   int       frame;
   CollType  type;
@@ -71,6 +55,9 @@ typedef struct{
   int          num_tags;
   slice_d      slices[MAX_ANIM_FRAMES];
   int          num_slices;
+
+  cJSON*       frame_meta;
+  cJSON*       slice_meta;
 }ase_sprite_sheet_d;
 bool LoadAsepriteSheet(cJSON*, ase_sprite_sheet_d*);
 

--- a/src/game_sprites.c
+++ b/src/game_sprites.c
@@ -83,8 +83,8 @@ void DrawSprite(sprite_t* spr, Vector2 pos){
   Rectangle src = s->bounds;
 
   Vector2 origin = (Vector2){
-    s->offset.x * spr->scale,//offset.x,
-      s->offset.y * spr->scale//offset.y
+    s->center.x * spr->scale,//center.x,
+      s->center.y * spr->scale//center.y
   };
 
   Vector2 position = Vector2Add(pos,s->center);
@@ -100,9 +100,6 @@ void DrawSprite(sprite_t* spr, Vector2 pos){
   DrawTexturePro(sheet,src,dst, origin, spr->rot, col);
 
   return;
-
-
-
 }
 
 void SpriteLoadSubTextures(sub_texture_t* data, SheetID id, int sheet_cap){

--- a/src/game_system.c
+++ b/src/game_system.c
@@ -114,6 +114,7 @@ void OnSystemEvent(event_t* ev, void* data){
     case GAME_EVENT_SET:
       state = ev->eid;
       SystemSet(w, s, state);
+      break;
     case GAME_EVENT_STATE:
       state = ev->eid;
       SystemState(w, s, state);

--- a/src/sprite_enum.h
+++ b/src/sprite_enum.h
@@ -1,0 +1,64 @@
+#ifndef __SPR_ENUM__
+#define __SPR_ENUM__
+#include "game_enum.h"
+
+#define EVENT_ANIM_BASE     0x5000
+#define EVENT_PARTICLE_BASE 0x6000
+
+DEFINE_EVENT_SPACE(AnimEvent, EVENT_ANIM_BASE);
+
+typedef enum{
+  ANIM_EVENT_NONE,
+  ANIM_EVENT_FRAME,
+  ANIM_EVENT_FRAME_START,
+  ANIM_EVENT_FRAME_END,
+  ANIM_EVENT_SEQ_END,
+  ANIM_EVENT_ATTACK,
+  ANIM_EVENT_COUNT
+}AnimEventID;
+
+typedef enum{
+  SHEET_UI,
+  SHEET_ICON,
+  SHEET_TILE,
+  SHEET_CHAR,
+  SHEET_MOB,
+  SHEET_OBJ,
+  SHEET_VFX,
+  SHEET_ALL
+}SheetID;
+
+typedef enum{
+  COL_NONE,
+  COL_HIT,
+  COL_HURT,
+}CollType;
+
+typedef enum{
+  LAYER_ROOT = -1,
+  LAYER_BG,
+  LAYER_FLOOR, 
+  LAYER_MAIN,
+  LAYER_TOP,
+  LAYER_UI,
+  LAYER_DONE
+}RenderLayer;
+
+typedef enum{
+  ANIM_NONE,
+  ANIM_START,
+  ANIM_IDLE,
+  ANIM_WALK,
+  ANIM_ATTACK,
+  ANIM_HURT,
+  ANIM_DIE,
+  ANIM_DONE
+}AnimState;
+
+typedef enum{
+  ANIM_BLANK,
+  ANIM_SUSPEND,
+  ANIM_HURTBOX,
+}AnimBehavior;
+
+#endif

--- a/src/system_define.h
+++ b/src/system_define.h
@@ -3,7 +3,7 @@
 #include "game_define.h"
 #include "component_define.h"
 
-#define NUM_FUNCTIONS 45
+#define NUM_FUNCTIONS 46
 
 extern hash_map_t SYSTEM_SINK;
 typedef struct{
@@ -67,9 +67,11 @@ typedef struct{
   int     count, cap;
   int     *ents;
 }sprite_layer_t;
+extern sprite_layer_t SPRITE_LAYERS[LAYER_DONE];
 
 void SpritesInit(world_t* w);
 void SpriteLoad(world_t* w, Entity e);
+void SpriteDrawPrep(world_t* w);
 
 typedef struct {
   Entity  ents[MAX_PARTICLES];
@@ -152,6 +154,8 @@ static system_function_lookup_t FUNCTION_LOOKUP[NUM_FUNCTIONS] = {
 
     {"SpritesInit",         SpritesInit},
     {"SpriteLoad",          SpriteLoad},
+    {"SpriteDrawPrep",          SpriteDrawPrep},
+
     {"ExpirationSystem",    ExpirationSystem}
 };
 

--- a/src/system_physics.c
+++ b/src/system_physics.c
@@ -104,7 +104,7 @@ void PhysicsLoad(world_t* w, Entity e){
   RigidBodySetBounds(rb, size);
 
   Vector2 offset = VEC_NEW(ac->hitbox.x, ac->hitbox.y);
-  RigidBodySetOffset(rb, size);
+  RigidBodySetOffset(rb, offset);
 }
 
 void PhysicsCollision(world_t* w, Entity e){

--- a/src/system_sprite.c
+++ b/src/system_sprite.c
@@ -1,7 +1,18 @@
 #include "system_define.h"
 #include "tool_lookup.h"
 
-sprite_layer_t SPRITE_LAYERS[LAYER_DONE] = {0};
+sprite_layer_t SPRITE_LAYERS[LAYER_DONE];
+
+int SpriteDepthSort(const void* a, const void* b)
+{
+    Entity ea = EntityGet(&world.manager, *(int*)a);
+    Entity eb = EntityGet(&world.manager, *(int*)b);
+    
+    position_t* pa = GET_COMPONENT(&world, ea, position_t, POS_ID);
+    position_t* pb = GET_COMPONENT(&world, eb, position_t, POS_ID);
+    
+    return (int)(pa->vpos.y - pb->vpos.y);   // Higher Y drawn later
+}
 
 void SpriteRender(world_t* w, RenderLayer l)
 {
@@ -11,8 +22,9 @@ void SpriteRender(world_t* w, RenderLayer l)
 
   for (int j = 0; j < layer->count; j++)
   {
-    Entity e = EntityGet(&w->manager, layer->ents[j]);
-    sprite_t* s   = GET_COMPONENT(w, e, sprite_t, SPR_ID);
+    int ent_id = layer->ents[j];
+    Entity e = EntityGet(&w->manager, ent_id);
+    sprite_t* s = GET_COMPONENT(w, e, sprite_t, SPR_ID);
     position_t* pos = GET_COMPONENT(w, e, position_t, POS_ID);
 
     if (s && pos)
@@ -27,31 +39,32 @@ void SpriteOnRender(void* o_data, void* s, void* e_data) {
   SpriteRender(w, r->layer);
 }
 
+void SpriteDrawPrep(world_t* w){
+  //TODO MARK SPRITE LAYER as dirty using component pool has_update on POSITION
+  for(int i = LAYER_FLOOR; i < LAYER_UI; i++)
+    qsort(SPRITE_LAYERS[i].ents, SPRITE_LAYERS[i].count, sizeof(int), SpriteDepthSort);
+}
+
 void SpriteLoad(world_t* w, Entity e)
 {
   sprite_t* s = GET_COMPONENT(w, e, sprite_t, SPR_ID);
-  if (!s){
-    TraceLog(LOG_WARNING, " ==== SPRITE LOAD ===\n sprite not found for Ent: %i", e.id);
-    return;
-  }
+  if (!s) return;
 
-  if (s->layer < LAYER_BG || s->layer >= LAYER_DONE)
-  {
-    TraceLog(LOG_WARNING, "==== SPRITE LOAD ===\n Ent %i invalid sprite layer %i", e.id, s->layer);
-    return;
-  }
+  if (s->layer < 0 || s->layer >= LAYER_DONE) return;
 
   sprite_layer_t* layer = &SPRITE_LAYERS[s->layer];
 
-  if (layer->count >= layer->cap)
-  {
-    TraceLog(LOG_WARNING, "Sprite layer %d is full (cap=%d)", s->layer, layer->cap);
+  if (layer->ents == NULL) {
+    TraceLog(LOG_ERROR, "CRITICAL: Layer %d ents pointer is NULL!", s->layer);
     return;
   }
 
-  // Safe assignment
-  layer->ents[layer->count] = e.id;
-  layer->count++;
+  if (layer->count >= layer->cap) {
+    TraceLog(LOG_WARNING, "Layer %d full", s->layer);
+    return;
+  }
+
+  layer->ents[layer->count++] = e.id;
 }
 
 void SpritesInit(world_t* w){
@@ -59,7 +72,7 @@ void SpritesInit(world_t* w){
     SPRITE_LAYERS[i].cap = MAX_LAYER_SPRITES;
     SPRITE_LAYERS[i].ents = GameCalloc("SpritesInit",
         MAX_LAYER_SPRITES, sizeof(int));
-     
+
     SubjectAddObserver(LookupLayer(i), "SPRITES", SpriteOnRender, w);
   }
 }

--- a/src/tool_lookup.h
+++ b/src/tool_lookup.h
@@ -2,6 +2,7 @@
 #define __TOOL_LOOK__
 
 #include "physics_enum.h"
+#include "sprite_enum.h"
 
 PhysicsEventID StringToPhysEvent(const char* str);
 ReactType StringToReaction(const char* str);
@@ -9,6 +10,8 @@ CameraTracking StringToCameraMode(const char* str);
 ActionType StringToAction(const char* str);
 Vector2 StringToVector2(const char* str);
 ForceType StringToForce(const char* str);
+
+CollType StringToCollType(const char* str);
 ShapeType StringToShape(const char* str);
 static const char* RENDER_LAYER_LOOK[LAYER_DONE] = {
   "LAYER_BACKGROUND",

--- a/src/tool_strings.c
+++ b/src/tool_strings.c
@@ -1,6 +1,7 @@
 #include "game_math.h"
 #include "physics_enum.h"
 #include "view_enum.h"
+#include "sprite_enum.h"
 
 #include <string.h>
 
@@ -59,6 +60,16 @@ PhysicsEventID StringToPhysEvent(const char* str){
   if (strcmp(str, "HIT") == 0)        return PHYS_EVENT_HIT;
 
   return PHYS_EVENT_NONE;
+}
+
+CollType StringToCollType(const char* str){
+  if(strcmp(str, "hitbox") == 0)      return COL_HIT;
+  if(strcmp(str, "hurtbox_0") == 0)   return COL_HURT;
+  if(strcmp(str, "hurtbox_90") == 0)  return COL_HURT;
+  if(strcmp(str, "hurtbox_180") == 0) return COL_HURT;
+  if(strcmp(str, "hurtbox_270") == 0) return COL_HURT;
+
+  return COL_NONE;
 }
 
 ShapeType StringToShape(const char* str){


### PR DESCRIPTION
**Title:**  Fix render pipeline texture offsets + implement sprite depth (Y) sorting

**Description:**

### Summary
Major improvement to the rendering pipeline: Fixed texture/hitbox offset issues with trimmed sprites and added proper **Y-based depth sorting** for sprites.

### Changes

**Bug Fixes:**
- Corrected hitbox and texture offset calculation by properly accounting for Aseprite `spriteSourceSize` (trim offsets).
- Fixed misalignment issues, especially noticeable on the rat sprite.

**New Feature:**
- Implemented **sprite depth sorting** (Y-sorting) within render layers.
- Sprites now draw in correct visual order based on Y position (higher Y = drawn later / appears in front).
- Essential for top-down games so characters can walk behind/in front of objects naturally.

**Technical Improvements:**
- Enhanced sprite sheet parsing for slices (`hitbox`, `hurtbox`, etc.).
- Updated `SpriteRender` and layer system to support sorting.
- Cleaner offset handling between sprites and rigidbodies.

### Result
- Hitboxes now align correctly with sprites.
- Natural depth ordering for entities (rats, player, barrels, etc.).
- Much more polished visual output.

Closes #43 
